### PR TITLE
Switch deprecated `include` to `include_tasks`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 
-- include: install.yml
+- include_tasks: install.yml
   when: jumpcloud_install
 
-- include: tag.yml
+- include_tasks: tag.yml
   when: jumpcloud_tag
 
-- include: cleanup.yml
+- include_tasks: cleanup.yml
   when: jumpcloud_image_build
 
-- include: deregister.yml
+- include_tasks: deregister.yml
   when: jumpcloud_shutdown_cleanup


### PR DESCRIPTION
This would make the role require at least Ansible 2.4, but it avoids unnecessary deprecation warnings.